### PR TITLE
Add explicit border style to work with Firefox 15

### DIFF
--- a/border-image-generator.js
+++ b/border-image-generator.js
@@ -113,7 +113,8 @@ $(document).ready(function() {
 
             borderImage = img + " " + joinValues(imageOffset);
             borderWidthStr = joinValues(borderWidth, "px ") + "px";
-            style = "border-width: " + borderWidthStr + ";\n"
+            style = "border-style: solid;\n"
+            	+ "border-width: " + borderWidthStr + ";\n"
                 + "-moz-border-image: " + borderImage + repeatStr + ";\n"
                 + "-webkit-border-image: " + borderImage + repeatStr + ";\n"
                 + "-o-border-image: " + borderImage + repeatStr + ";\n"

--- a/css/border-image-generator.css
+++ b/css/border-image-generator.css
@@ -36,6 +36,7 @@
 
 #cssEl {
     white-space: pre;
+    border-style: solid;
 }
 
 #editorEl {


### PR DESCRIPTION
No border image displays in Firefox 15, because it now requires an explicit `border-style` declaration, as [discussed here](http://stackoverflow.com/questions/12544271/firefox-15-div-content-spilling-to-border-image/12547729#12547729). 

This fixes that. 
